### PR TITLE
fix more warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.1)
 project(wings LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "-O3 -fPIC -Wall")
+set(CMAKE_CXX_FLAGS "-O3 -fPIC -Wall -Wextra")
 set(CMAKE_C_FLAGS "-O3 -fPIC -Wall")
 #set(CMAKE_CXX_FLAGS "-O0 -fsanitize=address")
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### **about**
+### **About**
 
 `wings` is a web interface for graphics applications. It is primarily intended for server-side rendering of meshes and solution fields for scientific applications, in which a mesh might be stored on a remote cluster or a cloud virtual machine (e.g. using GCP or AWS).
 
@@ -10,7 +10,7 @@ When running `wings` applications on a remote server, remember to forward the po
 
 Please see the GitHub Issues tab for a list of active projects and known bugs/limitations.
 
-### **core dependencies**
+### **Core dependencies**
 
 - `git`,
 - `CMake` (>= 3.1)
@@ -18,7 +18,7 @@ Please see the GitHub Issues tab for a list of active projects and known bugs/li
 - `OpenGL` (with `EGL` on Linux and `CoreGL` on OS X - these should be installed alongside `OpenGL`),
 - `stb` for writing JPEG images before encoding them and sending them to a client (this can be omitted if you are already using `stb` in your project - otherwise it will be downloaded automatically).
 
-### **optional dependencies (to run the sample applications)**
+### **Optional dependencies (to run the sample applications)**
 
 The utilities and sample applications require a few external repositories for IO. If the examples are being built, the `wings` configuration will automatically download, build and link to them. They will be located in the `third_party` directory and can be deleted with `make clean_extern`.
 
@@ -26,7 +26,7 @@ The utilities and sample applications require a few external repositories for IO
 - `tinyobjloader`: https://github.com/tinyobjloader/tinyobjloader
 - `libMeshb`: https://github.com/LoicMarechal/libMeshb
 
-#### **quickstart**
+#### **Quickstart**
 
 1. Clone the repository:
 
@@ -46,7 +46,7 @@ The utilities and sample applications require a few external repositories for IO
 
 Alternatively, you can try out the more complete hybrid mesh viewer by running `bin/vwing` and opening `wings/apps/vwing/index.html` (or https://middpolymer.github.io/wings/vwing/).
 
-#### **how `wings` works**
+#### **How `wings` works**
 
 `wings` communicates asynchronously between the client and server using a WebSocket connection (following RFC 6455). Each client connection spawns a new listener thread in the server which will listen for rendering requests. These requests are encoded by the client (sent as a string), and wings will decipher them as a specific event. The first character typically encodes the type of event (`K`: key-value, `M` is a mouse-motion event, `W` is a mouse-wheel event):
 
@@ -60,7 +60,7 @@ Please note that `wings` was specifically designed in this way to reduce latency
 
 It would also be possible to encode the client messages using JSON or protocol buffers, but that adds a dependency (and I tend to avoid using dependencies unless absolutely necessary).
 
-#### **using the `wings` API**
+#### **Using the `wings` API**
 
 The core `wings` functionality is provided as a single-header, single-source library (`wings.h` and `wings.cpp`). The `CMake` configuration will build the `wings` library, however, you can also directly compile `wings.cpp` while setting the include path to contain the `wings` repository.
 
@@ -76,11 +76,11 @@ You can then create a `RenderingServer` which accepts a derived `Scene` object a
 
 On the client side, you need to (1) create a `img` HTML element and (2) create a WebSocket connection handler. The `src` attribute of the `img` element can be assigned to the event data when the WebSocket handler receives a message from the server (the `onmessage` callback). You can then send messages to your specialized `Scene` using the `send` function of your WebSocket connection (using the message conventions described above). I recommend inspecting the `apps/xwing` source for a complete example.
 
-#### **reminders**
+#### **Reminders**
 
 Note that `OpenGL` contexts can share resources such as buffers and textures but **cannot** share containers, such as vertex array objects or framebuffer objects (holding the render buffer and depth buffer). A `glCanvas` utility structure is provided to store and handle these, which should be created for each client connection (i.e. in each `onconnect` callback).
 
-### **sample applications**
+### **Sample applications**
 
 #### **`xwing`**: example wing viewer
 
@@ -90,7 +90,7 @@ This is a minimal, self-contained example that includes everything needed to set
 
 This is a more complete program for rendering mixed-element meshes consisting of lines, triangles, quads, polygons, tetrahedra, prisms, pyramids and polyhedra. `vwing` also sets up a few default "fields" (attributes) corresponding to the element group number (or reference) or the cell id. You can cycle through the available fields by pressing the `f` key. `vwing` supports clipping planes as well as element "picking" and prints a message in the browser with the picked element information. After picking an element, you can press `c` to center the view on the picked element.
 
-#### **LICENSE**
+#### **License**
 
 All `wings` source code (`wings.h`, `wings.cpp` as well as all `C++`, `HTML`, `JavaScript` and `GLSL` code for the apps) is distributed under the Apache-2.0 License.
 

--- a/apps/xwing/main.cpp
+++ b/apps/xwing/main.cpp
@@ -455,10 +455,8 @@ class MeshScene : public Scene {
 
  private:
   const Mesh& mesh_;
-  float user_x{0}, user_y{0};
 
   int program;
-  GLuint vertex_array;
   GLuint point_buffer;
   GLuint triangle_buffer;
   GLuint edge_buffer;

--- a/apps/xwing/main.cpp
+++ b/apps/xwing/main.cpp
@@ -565,6 +565,7 @@ void MeshScene::onconnect() {
 
 bool MeshScene::render(const ClientInput& input, int client_idx,
                        std::string* msg) {
+  (void)(msg);  // ignore unused-but-set-parameter warning
   ClientView& view = view_[client_idx];
   msg = nullptr;
   bool updated = false;

--- a/util/array2d.h
+++ b/util/array2d.h
@@ -225,7 +225,7 @@ template <typename T, typename F = uint64_t> class array2d {
     } else {
       first_.reserve(n);
       length_.reserve(n);
-      data_.reserve(10 * n);
+      data_.reserve(max_item * n);
     }
   }
 

--- a/util/field.cpp
+++ b/util/field.cpp
@@ -21,6 +21,8 @@
 
 namespace wings {
 
+#define UNUSED(X) (void)(X)
+
 template <typename T>
 static void allocate(const Topology<T>& topology, ElementField<T>& field) {
   ASSERT(field.n() == 0);
@@ -53,6 +55,8 @@ template <typename T>
 void evaluate_basis(int order, const coord_t* x, coord_t* phi);
 template <typename T>
 void polytope_correction(index_t n, std::vector<coord_t>& phi) {
+  UNUSED(n);
+  UNUSED(phi);
   return;
 }
 
@@ -69,6 +73,7 @@ void polytope_correction<Polyhedron>(index_t n, std::vector<coord_t>& phi) {
 
 template <>
 void polytope_correction<Prism>(index_t n, std::vector<coord_t>& phi) {
+  UNUSED(n);
   phi.resize(6, 1.0 / 6.0);
 }
 
@@ -123,6 +128,7 @@ void evaluate_basis<Tet>(int order, const coord_t* x, coord_t* phi) {
 
 template <>
 void evaluate_basis<Polygon>(int order, const coord_t* x, coord_t* phi) {
+  UNUSED(x);
   if (order == 0)
     phi[0] = 1.0;
   else if (order == 1)
@@ -133,6 +139,7 @@ void evaluate_basis<Polygon>(int order, const coord_t* x, coord_t* phi) {
 
 template <>
 void evaluate_basis<Prism>(int order, const coord_t* x, coord_t* phi) {
+  UNUSED(x);
   if (order == 0)
     phi[0] = 1.0;
   else if (order == 1)
@@ -143,6 +150,7 @@ void evaluate_basis<Prism>(int order, const coord_t* x, coord_t* phi) {
 
 template <>
 void evaluate_basis<Pyramid>(int order, const coord_t* x, coord_t* phi) {
+  UNUSED(x);
   if (order == 0)
     phi[0] = 1.0;
   else if (order == 1)
@@ -153,6 +161,7 @@ void evaluate_basis<Pyramid>(int order, const coord_t* x, coord_t* phi) {
 
 template <>
 void evaluate_basis<Polyhedron>(int order, const coord_t* x, coord_t* phi) {
+  UNUSED(x);
   if (order == 0)
     phi[0] = 1.0;
   else if (order == 1)
@@ -209,6 +218,8 @@ static void evaluate_polyhedra(
     std::function<void(const coord_t* x, coord_t*)> f) {
   ASSERT(field.order() == 0);
   ASSERT(topology.n() == field.n());
+  UNUSED(vertices);
+  UNUSED(f);
   LOG << "[warning] not evaluating field on polyhedra";
   return;
 }
@@ -239,6 +250,7 @@ static void set_group(const Topology<T>& topology, ElementField<T>& field) {
 void FieldLibrary::set_defaults(const Mesh& mesh) {
   add("cell", 1, 0);
   auto f1 = [](const coord_t* x, coord_t* y) {
+    UNUSED(x);
     y[0] = double(rand()) / double(RAND_MAX);
   };
   fields_["cell"].evaluate(mesh, f1);
@@ -256,5 +268,7 @@ void FieldLibrary::set_defaults(const Mesh& mesh) {
   set_group(mesh.polyhedra(), field.polyhedra());
   set_group(mesh.polyhedra().faces(), field.polyhedra().faces());
 }
+
+#undef UNUSED
 
 }  // namespace wings

--- a/wings.cpp
+++ b/wings.cpp
@@ -780,6 +780,10 @@ void glRenderingContext::resize_canvas(int width, int height) {
                               static_cast<int>(height), EGL_NONE};
   surface = eglCreatePbufferSurface(display, config, surface_attribs);
   EGL_CHECK();
+#else
+  // ignore unused parameter warnings
+  (void)(width);
+  (void)(height);
 #endif
 }
 

--- a/wings.cpp
+++ b/wings.cpp
@@ -454,9 +454,8 @@ static std::map<EGLint, std::string> egl_error_string = {
     {EGL_BAD_NATIVE_WINDOW, "bad native window"},
     {EGL_CONTEXT_LOST, "context lost"}};
 
-#define EGL_CALL(X)                                                       \
+#define EGL_CHECK()                                                       \
   {                                                                       \
-    (X);                                                                  \
     EGLint error = eglGetError();                                         \
     if (error != EGL_SUCCESS)                                             \
       printf("EGL error in file %s at line %d: %s\n", __FILE__, __LINE__, \
@@ -464,7 +463,12 @@ static std::map<EGLint, std::string> egl_error_string = {
     assert(error == EGL_SUCCESS);                                         \
   }
 
-#define EGL_CHECK(X) EGL_CALL({})
+#define EGL_CALL(X) \
+  {                 \
+    (X);            \
+    EGL_CHECK();    \
+  }
+
 #endif
 
 // opcodes and GUID defined by RFC6455


### PR DESCRIPTION
### Summary

This PR ignores a few more warnings about unused parameters, as well as the following warning seen in the action for a separate project:

```
warning: ISO C++ forbids braced-groups within expressions [-Wpedantic]
  459 |     (X);                                                                  
      |     ^
wings.cpp:467: note: in expansion of macro ‘EGL_CALL’
  467 | #define EGL_CHECK(X) EGL_CALL({})
      |                      ^~~~~~~~
wings.cpp:697:3: note: in expansion of macro ‘EGL_CHECK’
  697 |   EGL_CHECK();
      |   ^~~~~~~~~
```

### Testing

Checked the build locally (macOS with CGL) as well as on a codespace (Linux with EGL).